### PR TITLE
Error getting SSL certificate

### DIFF
--- a/kubernetes-templating/cert-manager/cluster-issure.yaml
+++ b/kubernetes-templating/cert-manager/cluster-issure.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: p.zhivtsov@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+

--- a/kubernetes-templating/cert-manager/ns.yaml
+++ b/kubernetes-templating/cert-manager/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/kubernetes-templating/chartmuseum/values.yaml
+++ b/kubernetes-templating/chartmuseum/values.yaml
@@ -1,0 +1,12 @@
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    cert-manager.io/acme-challenge-type: http01
+  hosts:
+  - name: chartmuseum.34.65.16.175.nip.io
+    path: /
+    tls: true
+    tlsSecret: chartmuseum.34.65.16.175.nip.io


### PR DESCRIPTION
# Выполнено ДЗ №N

- [ - ] Основное ДЗ
- [ - ] Задание со *

## В процессе сделано

- не Всё

## Как запустить проект

- ниже

## Как проверить работоспособность

- Например, перейти по ссылке "https://chartmuseum.<EXTERNAL-IP>.nip.io/"

## PR checklist

- [ ✓ ] Выставлен label с темой домашнего задания

хронология выполнения команд:
```
helm repo add stable https://kubernetes-charts.storage.googleapis.com
kubectl create ns nginx-ingress
helm upgrade --install nginx-ingress stable/nginx-ingress --wait \
 --namespace=nginx-ingress \
 --version=1.41.3
helm repo add jetstack https://charts.jetstack.io
kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml
kubectl apply -f kubernetes-templating/cert-manager/ns.yaml
helm upgrade --install cert-manager jetstack/cert-manager --wait \
 --namespace=cert-manager \
 --version=0.16.1
kubectl apply -f kubernetes-templating/cert-manager/cluster-issure.yaml
kubectl create ns chartmuseum
helm upgrade --install chartmuseum stable/chartmuseum --wait \
 --namespace=chartmuseum \
 --version=2.13.2 \
 -f kubernetes-templating/chartmuseum/values.yaml
```

need help. есть проблема с получением let's encrypte сертификата:
> **kubectl logs cert-manager-7ddc5b4db-946p5 -n cert-manager**

```
...
I0913 05:59:16.404241       1 controller.go:152] cert-manager/controller/ingress-shim "msg"="syncing item" "key"="chartmuseum/chartmuseum-chartmuseum"
I0913 05:59:16.421788       1 controller.go:152] cert-manager/controller/CertificateTrigger "msg"="syncing item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.421931       1 conditions.go:173] Setting lastTransitionTime for Certificate "chartmuseum.34.65.16.175.nip.io" condition "Issuing" to 2020-09-13 05:59:16.421867326 +0000 UTC m=+114.380255472
I0913 05:59:16.422163       1 controller.go:162] cert-manager/controller/ingress-shim "msg"="finished processing work item" "key"="chartmuseum/chartmuseum-chartmuseum"
I0913 05:59:16.422432       1 controller.go:152] cert-manager/controller/CertificateRequestManager "msg"="syncing item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422470       1 controller.go:162] cert-manager/controller/CertificateRequestManager "msg"="finished processing work item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422494       1 controller.go:152] cert-manager/controller/CertificateIssuing "msg"="syncing item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422531       1 controller.go:162] cert-manager/controller/CertificateIssuing "msg"="finished processing work item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422560       1 controller.go:152] cert-manager/controller/CertificateKeyManager "msg"="syncing item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422711       1 controller.go:162] cert-manager/controller/CertificateKeyManager "msg"="finished processing work item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422745       1 controller.go:152] cert-manager/controller/CertificateMetrics "msg"="syncing item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422859       1 controller.go:162] cert-manager/controller/CertificateMetrics "msg"="finished processing work item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
I0913 05:59:16.422894       1 controller.go:152] cert-manager/controller/CertificateReadiness "msg"="syncing item" "key"="chartmuseum/chartmuseum.34.65.16.175.nip.io"
...
```



> **kubectl logs nginx-ingress-controller-5ddbdf4fc9-qsgmn -n nginx-ingress**

```
-------------------------------------------------------------------------------
NGINX Ingress controller
  Release:       v0.34.1
  Build:         v20200715-ingress-nginx-2.11.0-8-gda5fa45e2
  Repository:    https://github.com/kubernetes/ingress-nginx
  nginx version: nginx/1.19.1

-------------------------------------------------------------------------------

I0913 05:54:03.331926       6 flags.go:205] Watching for Ingress class: nginx
W0913 05:54:03.332366       6 flags.go:250] SSL certificate chain completion is disabled (--enable-ssl-chain-completion=false)
W0913 05:54:03.332506       6 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0913 05:54:03.332864       6 main.go:231] Creating API client for https://10.4.0.1:443
I0913 05:54:03.342030       6 main.go:275] Running in Kubernetes cluster version v1.16+ (v1.16.13-gke.1) - git (clean) commit 688c6543aa4b285355723f100302d80431e411cc - platform linux/amd64
I0913 05:54:03.346296       6 main.go:87] Validated nginx-ingress/nginx-ingress-default-backend as the default backend.
I0913 05:54:03.699098       6 main.go:105] SSL fake certificate created /etc/ingress-controller/ssl/default-fake-certificate.pem
W0913 05:54:03.736894       6 store.go:659] Unexpected error reading configuration configmap: configmaps "nginx-ingress-controller" not found
I0913 05:54:03.753106       6 nginx.go:263] Starting NGINX Ingress controller
I0913 05:54:05.253919       6 nginx.go:307] Starting NGINX process
I0913 05:54:05.253992       6 leaderelection.go:242] attempting to acquire leader lease  nginx-ingress/ingress-controller-leader-nginx...
W0913 05:54:05.255221       6 controller.go:395] Service "nginx-ingress/nginx-ingress-default-backend" does not have any active Endpoint
I0913 05:54:05.255455       6 controller.go:141] Configuration changes detected, backend reload required.
I0913 05:54:05.260218       6 status.go:86] new leader elected: nginx-ingress-controller-5ddbdf4fc9-x6dll
I0913 05:54:05.347744       6 controller.go:157] Backend successfully reloaded.
I0913 05:54:05.348066       6 controller.go:166] Initial sync, sleeping for 1 second.
I0913 05:54:45.222148       6 leaderelection.go:252] successfully acquired lease nginx-ingress/ingress-controller-leader-nginx
I0913 05:54:45.222446       6 status.go:86] new leader elected: nginx-ingress-controller-5ddbdf4fc9-qsgmn
W0913 05:59:16.402741       6 backend_ssl.go:46] Error obtaining X.509 certificate: no object matching key "chartmuseum/chartmuseum.34.65.16.175.nip.io" in local store
I0913 05:59:16.403091       6 event.go:278] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"chartmuseum", Name:"chartmuseum-chartmuseum", UID:"74619c75-b9c9-4ff9-81c3-ab9c70a4634f", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"191509", FieldPath:""}): type: 'Normal' reason: 'CREATE' Ingress chartmuseum/chartmuseum-chartmuseum
W0913 05:59:19.522071       6 controller.go:916] Service "chartmuseum/chartmuseum-chartmuseum" does not have any active Endpoint.
W0913 05:59:19.522122       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
I0913 05:59:19.522170       6 controller.go:141] Configuration changes detected, backend reload required.
I0913 05:59:19.612583       6 controller.go:157] Backend successfully reloaded.
W0913 05:59:22.855441       6 controller.go:916] Service "chartmuseum/chartmuseum-chartmuseum" does not have any active Endpoint.
W0913 05:59:22.855486       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
W0913 05:59:31.911016       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
I0913 05:59:45.236597       6 status.go:275] updating Ingress chartmuseum/chartmuseum-chartmuseum status from [] to [{34.65.183.17 }]
W0913 05:59:45.242174       6 backend_ssl.go:46] Error obtaining X.509 certificate: no object matching key "chartmuseum/chartmuseum.34.65.16.175.nip.io" in local store
I0913 05:59:45.242550       6 event.go:278] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"chartmuseum", Name:"chartmuseum-chartmuseum", UID:"74619c75-b9c9-4ff9-81c3-ab9c70a4634f", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"191685", FieldPath:""}): type: 'Normal' reason: 'UPDATE' Ingress chartmuseum/chartmuseum-chartmuseum
W0913 05:59:45.242709       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
I0913 06:01:29.444605       6 controller.go:141] Configuration changes detected, backend reload required.
I0913 06:01:29.444956       6 event.go:278] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"chartmuseum", Name:"chartmuseum-chartmuseum", UID:"74619c75-b9c9-4ff9-81c3-ab9c70a4634f", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"192307", FieldPath:""}): type: 'Normal' reason: 'DELETE' Ingress chartmuseum/chartmuseum-chartmuseum
I0913 06:01:29.577534       6 controller.go:157] Backend successfully reloaded.
W0913 06:02:02.076160       6 backend_ssl.go:46] Error obtaining X.509 certificate: no object matching key "chartmuseum/chartmuseum.34.65.16.175.nip.io" in local store
I0913 06:02:02.076402       6 event.go:278] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"chartmuseum", Name:"chartmuseum-chartmuseum", UID:"bbf0c141-ae57-4f51-bb59-a82831bd9b7d", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"192519", FieldPath:""}): type: 'Normal' reason: 'CREATE' Ingress chartmuseum/chartmuseum-chartmuseum
W0913 06:02:05.250479       6 controller.go:916] Service "chartmuseum/chartmuseum-chartmuseum" does not have any active Endpoint.
W0913 06:02:05.250540       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
I0913 06:02:05.250587       6 controller.go:141] Configuration changes detected, backend reload required.
I0913 06:02:05.348939       6 controller.go:157] Backend successfully reloaded.
W0913 06:02:08.583910       6 controller.go:916] Service "chartmuseum/chartmuseum-chartmuseum" does not have any active Endpoint.
W0913 06:02:08.583964       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
W0913 06:02:15.122980       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
10.172.0.3 - - [13/Sep/2020:06:02:33 +0000] "GET / HTTP/2.0" 200 367 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36" 369 0.002 [chartmuseum-chartmuseum-chartmuseum-8080] [] 10.0.1.6:8080 547 0.003 200 246bf0a53fb6f64c02d1813c2679a7e6
10.172.0.3 - - [13/Sep/2020:06:02:35 +0000] "GET / HTTP/2.0" 200 367 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36" 14 0.001 [chartmuseum-chartmuseum-chartmuseum-8080] [] 10.0.1.6:8080 547 0.001 200 3c4579dea6441133e686c75540e9ec25
10.172.0.3 - - [13/Sep/2020:06:02:36 +0000] "GET / HTTP/2.0" 200 367 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36" 14 0.001 [chartmuseum-chartmuseum-chartmuseum-8080] [] 10.0.1.6:8080 547 0.001 200 620a64ec8c56b2c47b34fb499400b582
10.172.0.3 - - [13/Sep/2020:06:02:36 +0000] "GET / HTTP/2.0" 200 367 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36" 14 0.001 [chartmuseum-chartmuseum-chartmuseum-8080] [] 10.0.1.6:8080 547 0.002 200 86dc0f0be66189b84c807bb127ef0ef4
10.172.0.3 - - [13/Sep/2020:06:02:36 +0000] "GET / HTTP/2.0" 200 367 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36" 14 0.001 [chartmuseum-chartmuseum-chartmuseum-8080] [] 10.0.1.6:8080 547 0.000 200 70a3ad1d4f42081bfd6ab64550bc425e
10.172.0.3 - - [13/Sep/2020:06:02:40 +0000] "GET / HTTP/2.0" 200 367 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36" 13 0.001 [chartmuseum-chartmuseum-chartmuseum-8080] [] 10.0.1.6:8080 547 0.001 200 345762cc0860ee47b7a4a5a46bc97557
I0913 06:02:45.236818       6 status.go:275] updating Ingress chartmuseum/chartmuseum-chartmuseum status from [] to [{34.65.183.17 }]
I0913 06:02:45.240752       6 event.go:278] Event(v1.ObjectReference{Kind:"Ingress", Namespace:"chartmuseum", Name:"chartmuseum-chartmuseum", UID:"bbf0c141-ae57-4f51-bb59-a82831bd9b7d", APIVersion:"networking.k8s.io/v1beta1", ResourceVersion:"192773", FieldPath:""}): type: 'Normal' reason: 'UPDATE' Ingress chartmuseum/chartmuseum-chartmuseum
W0913 06:02:45.241125       6 backend_ssl.go:46] Error obtaining X.509 certificate: no object matching key "chartmuseum/chartmuseum.34.65.16.175.nip.io" in local store
W0913 06:02:45.242012       6 controller.go:1132] Error getting SSL certificate "chartmuseum/chartmuseum.34.65.16.175.nip.io": local SSL certificate chartmuseum/chartmuseum.34.65.16.175.nip.io was not found. Using default certificate
```